### PR TITLE
ACA task framework refactoring (#275)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -194,3 +194,14 @@ RUN echo "6--- installing pulsar dependacies ---" && \
     apt install -y ./apache-pulsar-client*.deb && \
     rm -rf /var/local/git/pulsar
 
+RUN echo "7--- installing marl ---" && \
+    mkdir -p /var/local/git/marl && \
+    cd /var/local/git/marl && \
+    git clone https://github.com/google/marl.git && \
+    cd /var/local/git/marl/marl && \
+    git submodule update --init && \
+    mkdir /var/local/git/marl/marl/build && \
+    cd /var/local/git/marl/marl/build && \
+    cmake .. -DMARL_BUILD_EXAMPLES=1 -DMARL_BUILD_TESTS=1 && \
+    make && \
+    cd ~

--- a/build/aca-machine-init.sh
+++ b/build/aca-machine-init.sh
@@ -199,8 +199,20 @@ echo "6--- installing openvswitch dependancies ---" && \
     test -f /usr/bin/ovs-vsctl && rm -rf /usr/local/sbin/ov* /usr/local/bin/ov* /usr/local/bin/vtep* && \
     cd ~
 
+echo "7--- installing marl ---" && \
+    mkdir -p /var/local/git/marl && \
+    cd /var/local/git/marl && \
+    git clone https://github.com/google/marl.git && \
+    cd /var/local/git/marl/marl && \
+	  git submodule update --init && \
+	  mkdir /var/local/git/marl/marl/build && \
+	  cd /var/local/git/marl/marl/build && \
+	  cmake .. -DMARL_BUILD_EXAMPLES=1 -DMARL_BUILD_TESTS=1 && \
+    make && \
+    cd ~
+
 PULSAR_RELEASE_TAG='pulsar-2.8.1'
-echo "7--- installing pulsar dependacies ---" && \
+echo "8--- installing pulsar dependacies ---" && \
     mkdir -p /var/local/git/pulsar && \
     wget https://archive.apache.org/dist/pulsar/${PULSAR_RELEASE_TAG}/DEB/apache-pulsar-client.deb -O /var/local/git/pulsar/apache-pulsar-client.deb && \
     wget https://archive.apache.org/dist/pulsar/${PULSAR_RELEASE_TAG}/DEB/apache-pulsar-client-dev.deb -O /var/local/git/pulsar/apache-pulsar-client-dev.deb && \
@@ -209,7 +221,7 @@ echo "7--- installing pulsar dependacies ---" && \
     rm -rf /var/local/git/pulsar 
     cd ~
 
-echo "8--- building alcor-control-agent"
+echo "9--- building alcor-control-agent"
 cd $BUILD/.. && cmake . && \
 # after cmake ., modify the generated link.txt s so that the "-lssl" and "-lcrypto" appears after the openvswitch, so that it can compile
 sed -i 's/\(-ldl -lrt -lm -lpthread\)/-lssl -lcrypto \1/' src/CMakeFiles/AlcorControlAgent.dir/link.txt && \
@@ -217,12 +229,15 @@ sed -i 's/\(-ldl -lrt -lm -lpthread\)/-lssl -lcrypto \1/' test/CMakeFiles/aca_te
 sed -i 's/\(-ldl -lrt -lm -lpthread\)/-lssl -lcrypto \1/' test/CMakeFiles/gs_tests.dir/link.txt && \
 make
 if [ -n "$1" -a "$1" = "delete-bridges" ]; then
-  echo "9--- deleting br-tun and br-int if requested"
+  echo "10--- deleting br-tun and br-int if requested"
   PATH=$PATH:/usr/local/share/openvswitch/scripts \
       LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
   ovs-ctl --system-id=random --delete-bridges restart
 fi
 
-echo "10--- running alcor-control-agent"
-# sends output to null device, but stderr to console 
-nohup $BUILD/bin/AlcorControlAgent -d > /dev/null 2>&1 &
+echo "11--- running alcor-control-agent"
+# kill current AlcorControlAgent process if any
+pkill -f AlcorControlAgent
+# launch newly built AlcorControlAgent with default debug mode as 'false'
+# sends output to null device, but stderr to console
+nohup $BUILD/bin/AlcorControlAgent > /dev/null 2>&1 &

--- a/include/libfluid-base/base/EventLoop.hh
+++ b/include/libfluid-base/base/EventLoop.hh
@@ -17,6 +17,9 @@
 #ifndef __EVENTLOOP_HH__
 #define __EVENTLOOP_HH__
 
+#include "marl/defer.h"
+#include "marl/scheduler.h"
+
 namespace fluid_base {
 
 class BaseOFServer;
@@ -41,7 +44,7 @@ public:
 
     @param id event loop id
     */
-    EventLoop(int id);
+    EventLoop(int id, marl::Scheduler* scheduler);
     ~EventLoop();
 
     /**
@@ -80,6 +83,7 @@ private:
     class LibEventEventLoop;
     friend class LibEventEventLoop;
     LibEventEventLoop* m_implementation;
+    marl::Scheduler* m_scheduler;
 };
 
 }

--- a/include/of_controller.h
+++ b/include/of_controller.h
@@ -25,6 +25,11 @@
 #include "libfluid-msg/of10msg.hh"
 #include "libfluid-msg/of13msg.hh"
 
+#include "marl/defer.h"
+#include "marl/event.h"
+#include "marl/scheduler.h"
+#include "marl/waitgroup.h"
+
 #include <arpa/inet.h>
 #include <atomic>
 #include <vector>
@@ -40,6 +45,8 @@
 #include <set>
 #include <stdlib.h>
 #include <unordered_map>
+#include <chrono>
+
 
 using namespace fluid_base;
 using namespace fluid_msg;
@@ -56,8 +63,10 @@ public:
             switch_dpid_map(switch_dpid_map),
             port_id_map(port_id_map),
             OFServer(address, port, nthreads, secure,
-                     OFServerSettings().supported_version(4) // OF version 0x04 is OF 1.3
-                         .echo_interval(30)) { }
+                     OFServerSettings()
+                         .supported_version(4) // OF version 1 is OF 1.0 and version 4 is 1.3
+                         .echo_interval(30)) {
+                          }
 
     ~OFController() = default;
 
@@ -86,6 +95,7 @@ public:
     void packet_out(const char* br, const char* opt);
 
 private:
+
     // tracking xid (ovs transaction id)
     std::atomic<uint32_t> xid;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,12 +66,14 @@ link_libraries(/usr/lib/x86_64-linux-gnu/libuuid.so)
 link_libraries(/usr/lib/x86_64-linux-gnu/libevent_pthreads.so)
 link_libraries(/usr/lib/x86_64-linux-gnu/libpthread.so)
 link_libraries(/usr/local/lib/libopenvswitch.a) #this was installed by aca-machine-init.sh
+link_libraries(/var/local/git/marl/marl/build/libmarl.a)   #this was built by aca-machine-init.sh
 include_directories(${RDKAFKA_INCLUDE_DIR} ${CPPKAFKA_INCLUDE_DIR} ${PULSAR_INCLUDE_DIR} ${LIBEVENT_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/proto3)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/grpc)
 include_directories(/usr/local/include/openvswitch)
 include_directories(/usr/local/include/openflow)
+include_directories(/var/local/git/marl/marl/include)
 
 # Find Protobuf installation
 # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.

--- a/src/comm/aca_grpc.cpp
+++ b/src/comm/aca_grpc.cpp
@@ -31,6 +31,11 @@
 #include "aca_log.h"
 #include "aca_grpc.h"
 
+#include "marl/defer.h"
+#include "marl/event.h"
+#include "marl/scheduler.h"
+#include "marl/waitgroup.h"
+
 extern string g_grpc_server_port;
 extern string g_ncm_address;
 extern string g_ncm_port;
@@ -43,7 +48,6 @@ Status GoalStateProvisionerAsyncServer::ShutDownServer()
   ACA_LOG_INFO("%s", "Shutdown server");
   server_->Shutdown();
   cq_->Shutdown();
-  thread_pool_.stop();
   keepReadingFromCq_ = false;
   return Status::OK;
 }
@@ -275,15 +279,7 @@ void GoalStateProvisionerAsyncServer::AsyncWorkder()
 void GoalStateProvisionerAsyncServer::RunServer(int thread_pool_size)
 {
   ACA_LOG_INFO("Start of RunServer, pool size %ld\n", thread_pool_size);
-
-  thread_pool_.resize(thread_pool_size);
-  ACA_LOG_DEBUG("Async GRPC SERVER: Resized thread pool to %ld threads, start waiting for the pool to have enough threads\n",
-                thread_pool_size);
-  /* wait for thread pool to initialize*/
-  while (thread_pool_.n_idle() != thread_pool_.size()) {
-    ACA_LOG_DEBUG("%s\n", "Still waiting...sleep 1 ms");
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  };
+  
   ACA_LOG_DEBUG("Async GRPC SERVER: finised resizing thread pool to %ld threads\n",
                 thread_pool_size);
   //  Create the server
@@ -331,6 +327,8 @@ void GoalStateProvisionerAsyncServer::RunServer(int thread_pool_size)
 
   for (int i = 0; i < thread_pool_size; i++) {
     ACA_LOG_DEBUG("Pushing the %ldth async worker into the pool", i);
-    thread_pool_.push(std::bind(&GoalStateProvisionerAsyncServer::AsyncWorkder, this));
+    marl::schedule([=]{
+        AsyncWorkder();
+    });
   }
 }

--- a/src/dp_abstraction/aca_dataplane_ovs.cpp
+++ b/src/dp_abstraction/aca_dataplane_ovs.cpp
@@ -329,9 +329,9 @@ EXIT:
           culminative_network_configuration_time, operation_total_time);
 
   if (overall_rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("%s", "Successfully configured the port state.\n");
+    ACA_LOG_DEBUG("%s", "Successfully configured the port state.\n");
   } else if (overall_rc == EINPROGRESS) {
-    ACA_LOG_INFO("Port state returned pending: rc=%d\n", overall_rc);
+    ACA_LOG_DEBUG("Port state returned pending: rc=%d\n", overall_rc);
   } else {
     ACA_LOG_ERROR("Unable to configure the port state: rc=%d\n", overall_rc);
   }
@@ -541,9 +541,9 @@ int ACA_Dataplane_OVS::update_port_state_workitem(const PortState current_PortSt
           culminative_network_configuration_time, operation_total_time);
 
   if (overall_rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("%s", "Successfully configured the port state.\n");
+    ACA_LOG_DEBUG("%s", "Successfully configured the port state.\n");
   } else if (overall_rc == EINPROGRESS) {
-    ACA_LOG_INFO("Port state returned pending: rc=%d\n", overall_rc);
+    ACA_LOG_DEBUG("Port state returned pending: rc=%d\n", overall_rc);
   } else {
     ACA_LOG_ERROR("Unable to configure the port state: rc=%d\n", overall_rc);
   }
@@ -730,9 +730,7 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
           overall_rc, culminative_dataplane_programming_time,
           culminative_network_configuration_time, operation_total_time);
 
-  if (overall_rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("%s", "Successfully configured the neighbor state.\n");
-  } else {
+  if (overall_rc != EXIT_SUCCESS) {
     ACA_LOG_ERROR("Unable to configure the neighbor state: rc=%d\n", overall_rc);
   }
 
@@ -907,9 +905,7 @@ int ACA_Dataplane_OVS::update_neighbor_state_workitem(NeighborState current_Neig
     overall_rc = -EFAULT;
   }
 
-  if (overall_rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("%s", "Successfully configured the neighbor state.\n");
-  } else {
+  if (overall_rc != EXIT_SUCCESS) {
     ACA_LOG_ERROR("Unable to configure the neighbor state: rc=%d\n", overall_rc);
   }
   
@@ -965,7 +961,7 @@ int ACA_Dataplane_OVS::update_router_state_workitem(RouterState current_RouterSt
           culminative_network_configuration_time, operation_total_time);
 
   if (overall_rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("%s", "Successfully configured the router state.\n");
+    ACA_LOG_DEBUG("%s", "Successfully configured the router state.\n");
   } else {
     ACA_LOG_ERROR("Unable to configure the router state: rc=%d\n", overall_rc);
   }
@@ -1022,7 +1018,7 @@ int ACA_Dataplane_OVS::update_router_state_workitem(RouterState current_RouterSt
           culminative_network_configuration_time, operation_total_time);
 
   if (overall_rc == EXIT_SUCCESS) {
-    ACA_LOG_INFO("%s", "Successfully configured the router state.\n");
+    ACA_LOG_DEBUG("%s", "Successfully configured the router state.\n");
   } else {
     ACA_LOG_ERROR("Unable to configure the router state: rc=%d\n", overall_rc);
   }

--- a/src/ovs/aca_arp_responder.cpp
+++ b/src/ovs/aca_arp_responder.cpp
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <unistd.h>
 
+
 using namespace std;
 
 namespace aca_arp_responder
@@ -249,6 +250,7 @@ void ACA_ARP_Responder::arp_xmit(uint32_t in_port, void *vlanmsg, void *message,
     ACA_LOG_ERROR("%s", "Serialized ARP Reply is null!\n");
     return;
   }
+
   if (is_found) {
     options = inport + whitespace + packetpre + packet + whitespace + action;
     //delete the constructed arp reply
@@ -258,8 +260,7 @@ void ACA_ARP_Responder::arp_xmit(uint32_t in_port, void *vlanmsg, void *message,
   }
 
   ACA_LOG_DEBUG("ACA_ARP_Responder sent arp packet to ovs: %s\n", options.c_str());
-  //aca_ovs_control::ACA_OVS_Control::get_instance().packet_out(bridge.c_str(),
-  //                                                            options.c_str());
+
   aca_ovs_l2_programmer::ACA_OVS_L2_Programmer::get_instance().packet_out(bridge.c_str(),
                                                                           options.c_str());
 }
@@ -280,7 +281,7 @@ int ACA_ARP_Responder::_parse_arp_request(uint32_t in_port, vlan_message *vlanms
   } else {
     stData.vlan_id = 0;
   }
-
+  
   // if not find the corresponding mac address in the db based on ip and vlan id, resubmit to table 22
   // else construct an arp reply
   if (!_arp_db.find(stData, current_arp_data)) {

--- a/src/ovs/aca_ovs_l2_programmer.cpp
+++ b/src/ovs/aca_ovs_l2_programmer.cpp
@@ -28,7 +28,6 @@
 #include <netdb.h>
 #include <ifaddrs.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <linux/if_link.h>
 
@@ -598,7 +597,7 @@ void ACA_OVS_L2_Programmer::execute_ovsdb_command(const std::string cmd_string,
 
   g_total_execute_ovsdb_time += ovsdb_client_time_total_time;
 
-  ACA_LOG_INFO("Elapsed time for ovsdb client call took: %ld microseconds or %ld milliseconds. rc: %d, cmd: [%s]\n",
+  ACA_LOG_DEBUG("Elapsed time for ovsdb client call took: %ld microseconds or %ld milliseconds. rc: %d, cmd: [%s]\n",
                ovsdb_client_time_total_time, us_to_ms(ovsdb_client_time_total_time),
                rc, ovsdb_cmd_string.c_str());
 
@@ -628,7 +627,7 @@ void ACA_OVS_L2_Programmer::execute_openflow_command(const std::string cmd_strin
 
   g_total_execute_openflow_time += openflow_client_time_total_time;
 
-  ACA_LOG_INFO("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds. rc: %d\n",
+  ACA_LOG_DEBUG("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds. rc: %d\n",
                openflow_client_time_total_time,
                us_to_ms(openflow_client_time_total_time), rc);
 
@@ -657,9 +656,9 @@ void ACA_OVS_L2_Programmer::execute_openflow(ulong &culminative_time,
 
   g_total_execute_openflow_time += openflow_client_time_total_time;
 
-  // ACA_LOG_INFO("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds.\n",
-  //              openflow_client_time_total_time,
-  //              us_to_ms(openflow_client_time_total_time));
+  ACA_LOG_DEBUG("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds.\n",
+               openflow_client_time_total_time,
+               us_to_ms(openflow_client_time_total_time));
 
   ACA_LOG_DEBUG("%s", "ACA_OVS_L2_Programmer::execute_openflow ---> Exiting\n");
 }
@@ -681,7 +680,7 @@ void ACA_OVS_L2_Programmer::packet_out(const char *bridge, const char *options)
 
   g_total_execute_openflow_time += openflow_client_time_total_time;
 
-  ACA_LOG_INFO("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds.\n",
+  ACA_LOG_DEBUG("Elapsed time for openflow client call took: %ld microseconds or %ld milliseconds.\n",
                openflow_client_time_total_time,
                us_to_ms(openflow_client_time_total_time));
 

--- a/src/ovs/libfluid-base/OFConnection.cc
+++ b/src/ovs/libfluid-base/OFConnection.cc
@@ -1,5 +1,6 @@
 #include "libfluid-base/base/BaseOFConnection.hh"
 #include "libfluid-base/OFConnection.hh"
+#include "libfluid-base/base/BaseOFConnection.hh"
 
 namespace fluid_base {
 
@@ -53,7 +54,7 @@ OFHandler* OFConnection::get_ofhandler() {
 
 void OFConnection::send(void* data, size_t len) {
     if (this->conn != NULL)
-        this->conn->send((uint8_t*) data, len);
+        this->conn->send((uint8_t*) data, len);    
 }
 
 void OFConnection::add_timed_callback(void* (*cb)(void*),

--- a/src/ovs/of_message.cpp
+++ b/src/ovs/of_message.cpp
@@ -28,6 +28,7 @@
 #include <openvswitch/ofp-parse.h>
 #include <openvswitch/ofp-print.h>
 
+
 enum {
     ADD_FLOW = 0,
     MODIFY_FLOW = 1,

--- a/src/ovs/ovs_control.cpp
+++ b/src/ovs/ovs_control.cpp
@@ -16,7 +16,11 @@
 #include "aca_log.h"
 #include "aca_util.h"
 #include "ovs_control.h"
-#include "aca_on_demand_engine.h"
+#undef OFP_ASSERT
+#undef CONTAINER_OF
+#undef ARRAY_SIZE
+#undef ROUND_UP
+// #include "aca_on_demand_engine.h"
 #include <sstream> // std::(istringstream)
 #include <string> // std::(string)
 #include <signal.h>
@@ -41,7 +45,7 @@
 #include <openvswitch/vlog.h>
 
 using namespace std;
-using namespace aca_on_demand_engine;
+// using namespace aca_on_demand_engine;
 
 extern std::atomic_ulong g_total_execute_openflow_time;
 
@@ -1012,7 +1016,7 @@ void OVS_Control::monitor_vconn(vconn *vconn, bool reply_to_echo_requests,
             The pin.packet here has the same memory address, even after multiple calls.
             If you intent to store it somewhere, it is advised to make a copy of it.
           */
-                    ACA_On_Demand_Engine::get_instance().parse_packet(in_port, pin.packet);
+                    // ACA_On_Demand_Engine::get_instance().parse_packet(in_port, pin.packet);
 
                     if (error) {
                         fprintf(stderr, "decoding packet-in failed: %s",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,9 @@ FIND_LIBRARY(MESSAGEMANAGER messagemanager ${CMAKE_CURRENT_SOURCE_DIR}/../includ
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/proto3)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/grpc)
+include_directories(/var/local/git/marl/marl/include)
 link_libraries(${PULSAR})
+link_libraries(/var/local/git/marl/marl/build/libmarl.a)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/test/func_tests/gs_tests.cpp
+++ b/test/func_tests/gs_tests.cpp
@@ -79,6 +79,7 @@ std::atomic_ulong g_total_vpcs_table_mutex_time(0);
 std::atomic_ulong g_total_update_GS_time(0);
 // total time for ACA message in microseconds
 std::atomic_ulong g_total_ACA_Message_time(0);
+
 bool g_demo_mode = false;
 bool g_debug_mode = false;
 

--- a/test/gtest/aca_test_arp.cpp
+++ b/test/gtest/aca_test_arp.cpp
@@ -13,10 +13,10 @@
 //     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "gtest/gtest.h"
+#include "aca_ovs_l2_programmer.h"
 #define private public
 #include "aca_arp_responder.h"
 #include "aca_net_config.h"
-#include "aca_ovs_l2_programmer.h"
 #include "aca_comm_mgr.h"
 #include "aca_util.h"
 #include "goalstate.pb.h"

--- a/test/gtest/aca_test_dhcp.cpp
+++ b/test/gtest/aca_test_dhcp.cpp
@@ -13,11 +13,11 @@
 //     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "gtest/gtest.h"
+#include "aca_ovs_l2_programmer.h"
 #define private public
 #include "aca_dhcp_server.h"
 #include "aca_dhcp_programming_if.h"
 #include "aca_net_config.h"
-#include "aca_ovs_l2_programmer.h"
 #include "aca_comm_mgr.h"
 #include "aca_util.h"
 #include "goalstate.pb.h"

--- a/test/gtest/aca_test_oam.cpp
+++ b/test/gtest/aca_test_oam.cpp
@@ -13,6 +13,7 @@
 //     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "gtest/gtest.h"
+#include "aca_ovs_l2_programmer.h"
 #include "goalstateprovisioner.grpc.pb.h"
 #define private public
 #include "aca_zeta_oam_server.h"
@@ -20,7 +21,6 @@
 #include <string.h>
 #include "aca_vlan_manager.h"
 #include "aca_zeta_programming.h"
-#include "aca_ovs_l2_programmer.h"
 
 #undef OFP_ASSERT
 #undef CONTAINER_OF

--- a/test/gtest/aca_test_zeta_programming.cpp
+++ b/test/gtest/aca_test_zeta_programming.cpp
@@ -13,11 +13,11 @@
 //     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "gtest/gtest.h"
+#include "aca_ovs_l2_programmer.h"
 #define private public
 #include "aca_util.h"
 #include "goalstateprovisioner.grpc.pb.h"
 #include <string.h>
-#include "aca_ovs_l2_programmer.h"
 #include "aca_comm_mgr.h"
 #include "aca_zeta_programming.h"
 #include "aca_util.h"


### PR DESCRIPTION
* Changed ACA's openflow version from 1.3 to 1.0

* Added tunnel_id printout, and commented out some unused code

* Try to make packet out to the bridge based on the of_connection_id

* Changed more code to let packet out based on of_connection_i

* Changed implementation for adding/removing switches in of_controller, in order to prevent deadlock

* Try to make on-demand packet_out based on the connection_id, rather than bridge name

* Added logs, in order to investigate why ofconnection dropped

* Suspect removing switches with empty name causes the problem

* Modifed arp_responder to avoid calling NCM

* Added local map lookup

* Initiate marl integration for packet-in stress testing

* Move libfluid packet-in parsing also to async scheduler, to release message_callback full capacity of receiving packets

* Break parse ARP job

* Test setting specific worker thread number

* Do not break parse job but set specific worker size

This reverts commit 42716a10cb93873df68b4270b51713b50b2ba1fb.

* Try to make atomic counter for packet_in

* Try to make atomic counter for packet_in

* Try to make atomic counter for packet_in

* Try to make atomic counter for packet_in

* Try to make atomic counter for packet_in

* Try to make atomic counter for packet_in

* Added sleep 100 us in marl code when packet in

* Added packet_out_counter, also made the counters global

* Added packet_out_counter, also made the counters global

* Print out both counters every 1 second

* Commented out arp_recv and see if the bottleneck is in the on-demand engine

* Changed packet_out_counter++ to the start of parse_packet, then return immediately

* Changed packet_out_counter++ to the start of parse_packet, then return immediately

* Change it to right inside the arp ether type

* Change it to before arp ether type

* Change it to before vlan ether type

* Change it to before

* Commented out ACA_LOG_INFOs on the packet_in to packet_out path

* Confirm on_demand_engine is already fast

* Put the count into the arp_recv

* Put the count into the arp_recv

* Added fmt library and sample fmt code

* Set counter before sprintf to get a baseline for comparison

* Set counter before sprintf to get a baseline for comparison

* Set counter before sprintf to get a baseline for comparison

* Set counter after 5 sprintf and string.append

* Set counter after 5 sprintf and string.append

* set counter after for loops

* set counter after if statement

* set counter before return

* _serialize_arp_message isn't a bottleneck?

* have to do it again with 4 switches in cbench

* after first five sprintf and string.append

* after for loops

* before return

* Try to rewrite _serialize_arp_message with fmt code

* try to call condense format_to to fewer ones

* comment out append to see if it takes a lot of time

* Try to use FMT_COMPILE when calling format_to

* do test with fmt

* Check qps before packet out

* let packet out go and test again

* Comment out time recording and test again

* put counter before is_found

* put counter at the beginning of packet_out

* add packet out counter to packet out

* place counter in ofcontroller::packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* place counter in create_packet_out

* testing without std::move

* testing without std::move

* remove lock

* put counter after create_packet_out

* put counter after send_packet_out

* use marl to send packet out

* added marl code to BaseOFConnection::send

* Disabled marl scheduling for OFConnection

* try to send flow_mod when receiving a packet_in

* enabled send packet out again, and test if cbench's OFPT_VENDOR should also count

* use marl to send flow_mod

* test parse_packet with marl

* Bring back gRPC client/server for testing

* Reverted OF version from 1.0 to 1.3

* comment out set ports' vlan tag for testing

* bring back adding getting ovs connections with bridge name

* added logs to investigate why no ovs flows are set up

* modified of message version

* commented out logs and time calculations to speed up the gs processing

* Try to use marl to update neighbor states

* Try to use marl to manage the whole gRPC server, so that update neighbor state can use marl, too

* Added waitGroup.wait()

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Check what should be the size of the wait group

* Use neighbor_count as waitGroup count; also changed back to for each loop when updating neighbor states

* try not to use defer()

* add one in waitgroup when iter through 1 neighbor

* Try to use barrier request/reply to check neighbor procecssing time

* added endl to printout

* Try to send barrier request at the 950k th neighbor creation

* Changed to send barrier request at the 970k th neighbor creation

* try to use marl to furthur schedule create l2 neighbor

* try to use marl to schedule execute_openflow when create_l2_neighbor

* comment out duplicated part

* comment out duplicated part

* comment out extra code

* revert back changes

* enable counter again

* put second counter after assert revision number

* put second counter after invalid argument checks

* increment first counter before marl schedule

* put second counter at the beginning of update_neighbor_state_workitem

* Improve performance by reducing unnecessary syslogs

* Use marl::schedule to process netowrk resource states

* added waitgroup to marl::schedule

* added marl::schedule to on-demand engine

* bring back original _parse_arp_request, in order to test with NCM

* add changes from #272

* Reverted ACA_ARP_Responder::_serialize_arp_message

* Cleaned up code

* Cleaned up more code

* Changed multiple logs from INFO to DEBUG

* Add marl dependencies in cmake as well as machine init script

* Fix marl dependency location in test cmake

* Fix docker file marl dependency

* Fix spaces

* removed fmt library related code

* corrected comment about OpenFlow Version

* Tried to fix the memory leak

* fixed blank lines and identation

* Always restart AlcorControlAgent with new build, and set default debug flag to false in aca-machine-init

Co-authored-by: Longzhang Fu <lfu@futurewei.com>